### PR TITLE
解决调用停止录音无效的bug

### DIFF
--- a/library/src/main/java/com/czt/mp3recorder/MP3Recorder.java
+++ b/library/src/main/java/com/czt/mp3recorder/MP3Recorder.java
@@ -66,13 +66,13 @@ public class MP3Recorder {
 		if (mIsRecording) return;
 	    initAudioRecorder();
 		mAudioRecord.startRecording();
+		mIsRecording = true;
 		new Thread() {
 
 			@Override
 			public void run() {
 				//设置线程权限
 				android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO);
-				mIsRecording = true;
 				while (mIsRecording) {
 					int readSize = mAudioRecord.read(mPCMBuffer, 0, mBufferSize);
 					if (readSize > 0) {


### PR DESCRIPTION
mIsRecording = true; 这个放主线程里，可防止mIsRecording 值在子线程里被覆盖导致无法停止录音。

解决了这个问题
[https://github.com/GavinCT/AndroidMP3Recorder/issues/19](#19)
